### PR TITLE
Support regex in :skip-routes

### DIFF
--- a/src/ring/middleware/okta.clj
+++ b/src/ring/middleware/okta.clj
@@ -39,8 +39,8 @@
   :redirect-after-logout - the destination URL to be redirected to after a `POST /logout`
                            (defaults to \"/\")
 
-  :skip-routes           - a list of routes to skip Okta authentication
-                           e.g. [:get \"/about\" :any \"/contact\"]
+  :skip-routes           - a list of routes as a string or regex to skip Okta authentication
+                           e.g. [:get \"/about\" :any \"/contact\" :get \"/home/\\S+\"]
 
   :force-user            - a default user to be used for development"
 

--- a/src/ring/ring_okta/predicates.clj
+++ b/src/ring/ring_okta/predicates.clj
@@ -1,5 +1,6 @@
 (ns ring.ring-okta.predicates
-  (:require [ring.util.request :as ring-request]))
+  (:require [ring.util.request :as ring-request]
+            [clojure.string :as str]))
 
 (def not-nil? (comp not nil?))
 
@@ -17,7 +18,7 @@
 (defn- match-pair? [[skip-method skip-path] request-method request-path]
   (and (or (= :any skip-method)
            (= skip-method request-method))
-       (= skip-path request-path)))
+       (str/starts-with? request-path skip-path)))
 
 (defn skip-route? [{:keys [request-method] :as request} skip-routes]
   (when skip-routes

--- a/src/ring/ring_okta/predicates.clj
+++ b/src/ring/ring_okta/predicates.clj
@@ -18,7 +18,7 @@
 (defn- match-pair? [[skip-method skip-path] request-method request-path]
   (and (or (= :any skip-method)
            (= skip-method request-method))
-       (str/starts-with? request-path skip-path)))
+       (not-nil? (re-matches (re-pattern skip-path) request-path))))
 
 (defn skip-route? [{:keys [request-method] :as request} skip-routes]
   (when skip-routes

--- a/src/ring/ring_okta/predicates.clj
+++ b/src/ring/ring_okta/predicates.clj
@@ -1,6 +1,5 @@
 (ns ring.ring-okta.predicates
-  (:require [ring.util.request :as ring-request]
-            [clojure.string :as str]))
+  (:require [ring.util.request :as ring-request]))
 
 (def not-nil? (comp not nil?))
 

--- a/test/ring/middleware/okta_test.clj
+++ b/test/ring/middleware/okta_test.clj
@@ -86,6 +86,12 @@
         (let [handler (wrap-okta default-handler okta-home {:force-user "foo@bar.com"
                                                             :skip-routes [:get "/foo"]})
               response (handler (request :get "/foo"))]
+          (is (= "foo@bar.com" (-> response :body :session :okta/user))))))
+
+      (testing "#force-user"
+            (testing "with :force-user defined"
+                   (let [handler (wrap-okta default-handler okta-home {:force-user "foo@bar.com"})
+                                                 response (handler (request :get "/foo"))]
           (is (= "foo@bar.com" (-> response :body :session :okta/user)))))
 
       (testing "without :force-user defined"

--- a/test/ring/middleware/okta_test.clj
+++ b/test/ring/middleware/okta_test.clj
@@ -58,6 +58,11 @@
               response (handler (request :get "/foo"))]
           (is (= "/foo" (-> response :body :uri)))))
 
+      (testing "with :skip-routes as a base root defined"
+        (let [handler (wrap-okta default-handler okta-home {:skip-routes [:get "/foo"]})
+              response (handler (request :get "/foo/bar"))]
+          (is (= "/foo/bar" (-> response :body :uri)))))
+
       (testing "without :skip-routes defined"
         (let [handler (wrap-okta default-handler okta-home)
               response (handler (request :get "/foo"))]

--- a/test/ring/middleware/okta_test.clj
+++ b/test/ring/middleware/okta_test.clj
@@ -58,10 +58,24 @@
               response (handler (request :get "/foo"))]
           (is (= "/foo" (-> response :body :uri)))))
 
-      (testing "with :skip-routes as a base root defined"
-        (let [handler (wrap-okta default-handler okta-home {:skip-routes [:get "/foo"]})
+      (testing "with :skip-routes - blocks only defined path"
+        (let [handler (wrap-okta default-handler okta-home {:skip-routes [:get "/foo/bar"]})
               response (handler (request :get "/foo/bar"))]
           (is (= "/foo/bar" (-> response :body :uri)))))
+
+      (testing "with :skip-routes - blocks only defined path"
+        (let [handler (wrap-okta default-handler okta-home {:skip-routes [:get "/foo"]})
+              response (handler (request :get "/foo/bar"))]
+          (is (= nil (-> response :body :uri)))))
+
+      (testing "with :skip-routes - blocks path defined in regex"
+        (let [handler (wrap-okta default-handler okta-home {:skip-routes [:get "/foo/\\S*"]})]
+          (is (= "/foo/" (-> (handler (request :get "/foo/")) :body :uri)))
+          (is (= "/foo/bar" (-> (handler (request :get "/foo/bar")) :body :uri)))
+          (is (= "/foo/bar/foo" (-> (handler (request :get "/foo/bar/foo")) :body :uri)))
+
+          (is (= nil (-> (handler (request :get "/foo")) :body :uri)))
+          (is (= nil (-> (handler (request :get "/bar/foo")) :body :uri)))))
 
       (testing "without :skip-routes defined"
         (let [handler (wrap-okta default-handler okta-home)
@@ -71,12 +85,6 @@
       (testing "with :force-user defined"
         (let [handler (wrap-okta default-handler okta-home {:force-user "foo@bar.com"
                                                             :skip-routes [:get "/foo"]})
-              response (handler (request :get "/foo"))]
-          (is (= "foo@bar.com" (-> response :body :session :okta/user))))))
-
-    (testing "#force-user"
-      (testing "with :force-user defined"
-        (let [handler (wrap-okta default-handler okta-home {:force-user "foo@bar.com"})
               response (handler (request :get "/foo"))]
           (is (= "foo@bar.com" (-> response :body :session :okta/user)))))
 


### PR DESCRIPTION
This allows you to specify a base route in :skip-routes option. So any route which is after the base route is also bypassed.
Example:

`{:skip-routes [:get "/foo"] }`

This will skip following routes instead of skipping just "/foo"
- "/foo/bar"
- "/foo/bar/something"
- "/foo"
