### PR TITLE
use tuple as local repo as shown by lein docs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/bostonaholic/ring-okta"
   :license {:name "The MIT License (MIT)"
             :url "https://mit-license.org"}
-  :repositories {"local" ~(str (.toURI (java.io.File. "maven_repository")))}
+  :repositories [["local" ~(str (.toURI (java.io.File. "maven_repository")))]]
   :dependencies [[org.clojure/clojure "1.10.2" :scope "provided"]
                  [org.clojure/core.incubator "0.1.4"]
                  [ring/ring-core "1.9.4" :scope "provided" :exclusions [commons-codec]]


### PR DESCRIPTION
Trying to fix missing okta jar that should be in the local repository: https://app.circleci.com/pipelines/github/cljdoc/builder/21735/workflows/937217e7-3255-4aa0-85aa-f10c3a0a9330/jobs/38110?invite=true#step-104-105